### PR TITLE
remove spacy from test script

### DIFF
--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -7,7 +7,7 @@ tests:
         cd text
         git checkout ${TEXT_COMMIT}
         rm -rf torchtext
-        conda install -y pytest mock sentencepiece spacy nltk
+        conda install -y pytest mock sentencepiece nltk
         pip install revtok
   - name: Run TorchText tests
     command: |


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Remove spacy as conflict is seen for py38 during Test environment setup when spacy has not been built locally. Also tests are passing without it. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
