### PR TITLE
fix build on cpu container

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,0 +1,5 @@
+build_type:
+  - "cpu"
+
+pytorch_select_version:
+  - "1.0"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0101-disable-tcmalloc.patch
 
 build:
-  number: 1
+  number: 2
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   ignore_run_exports:
     - libgcc-ng
@@ -30,6 +30,7 @@ requirements:
     - libstdcxx-ng  {{ libstdcxx }}
   host:
     - python {{ python }}
+    - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base     {{ pytorch }}
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
@@ -37,6 +38,7 @@ requirements:
   run:
     - numpy {{ numpy }}
     - python {{ python }}
+    - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base {{ pytorch }}
     - requests {{ requests }}
     - tqdm {{ tqdm }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0101-disable-tcmalloc.patch
 
 build:
-  number: 2
+  number: 1
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   ignore_run_exports:
     - libgcc-ng
@@ -38,7 +38,6 @@ requirements:
   run:
     - numpy {{ numpy }}
     - python {{ python }}
-    - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base {{ pytorch }}
     - requests {{ requests }}
     - tqdm {{ tqdm }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ requirements:
     - libstdcxx-ng  {{ libstdcxx }}
 
 test:
+  requires:
+    - _pytorch_select  {{ pytorch_select_version }}
   imports:
     - torchtext
     - torchtext.data

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0101-disable-tcmalloc.patch
 
 build:
-  number: 1
+  number: 2
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   ignore_run_exports:
     - libgcc-ng


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Build on CPU container, failed with the following error:

```
from torch._C import *
ImportError: libcupti.so.10.2: cannot open shared object file: No such file or directory
-----
-----
[OPEN-CE-ERROR]-11 Unable to build recipe: torchtext-feedstock
```
because it is using `CUDA pytorch base`.  And `import torch` for cuda pytorch-base fails on CPU container due to unavailability of CUDA libs. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
