### PR TITLE
add cpu and cuda variants for torchtext

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -1,0 +1,6 @@
+recipes:
+  - name : torchtext-base
+    path : recipe
+
+  - name : torchtext-meta
+    path : variants

--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,0 +1,12 @@
+build_type:
+  - "cpu"
+  - "cuda"
+
+pytorch_select_version:
+  - "1.0"
+  - "2.0"
+
+# Tie pytorch_select_version to build_type
+zip_keys:
+  - pytorch_select_version
+  - build_type

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "torchtext" %}
+{% set name = "torchtext-base" %}
 {% set version = "0.11.0" %}
 
 package:
@@ -13,8 +13,9 @@ source:
     - 0101-disable-tcmalloc.patch
 
 build:
-  number: 1
-  string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
+  number: 2
+  string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
+  string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 
 requirements:
   build:
@@ -24,11 +25,13 @@ requirements:
     - patch
   host:
     - python {{ python }}
+    - _pytorch_select  {{ pytorch_select_version }}
     - pytorch-base     {{ pytorch }}
   run:
     - numpy {{ numpy }}
     - python {{ python }}
-    - pytorch-base {{ pytorch }}
+    - _pytorch_select  {{ pytorch_select_version }}
+    - pytorch-base     {{ pytorch }}
     - requests {{ requests }}
     - tqdm {{ tqdm }}
     - sentencepiece {{ sentencepiece }}

--- a/variants/meta.yaml
+++ b/variants/meta.yaml
@@ -1,4 +1,4 @@
-# A metapackge for installing GPU or CPU versions of torchvision explicitly
+# A metapackge for installing GPU or CPU versions of torchtext explicitly
 
 {% set version = "0.11.0" %}
 
@@ -24,8 +24,8 @@ about:
   license_family: BSD
   summary: Meta-package to install torchtext variant for {{ 'GPU-enabled' if build_type == 'cuda' else 'CPU-only' }} pytorch 
   description: Meta-package to install torchtext varaint for {{ 'GPU-enabled' if build_type == 'cuda' else 'CPU-only' }} pytorch 
-  dev_url: https://github.com/pytorch/vision
-  doc_url: https://pytorch.org/docs/stable/torchvision/index.html
+  dev_url: https://github.com/pytorch/text
+  doc_url: https://pytorch.org/text/stable/index.html
 
 extra:
   recipe-maintainers:

--- a/variants/meta.yaml
+++ b/variants/meta.yaml
@@ -1,0 +1,32 @@
+# A metapackge for installing GPU or CPU versions of torchvision explicitly
+
+{% set version = "0.11.0" %}
+
+package:
+  name: torchtext{{ '-cpu' if build_type == 'cpu' else '' }}
+  version: {{ version }} 
+
+build:
+  number: 1
+  string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
+  string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
+
+requirements:
+  run:
+    - pytorch-base {{ pytorch }}
+    - _pytorch_select {{ pytorch_select_version }}
+    - torchtext-base {{ torchtext }}
+    - python {{ python }}
+
+about:
+  home: http://pytorch.org/
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: Meta-package to install torchtext variant for {{ 'GPU-enabled' if build_type == 'cuda' else 'CPU-only' }} pytorch 
+  description: Meta-package to install torchtext varaint for {{ 'GPU-enabled' if build_type == 'cuda' else 'CPU-only' }} pytorch 
+  dev_url: https://github.com/pytorch/vision
+  doc_url: https://pytorch.org/docs/stable/torchvision/index.html
+
+extra:
+  recipe-maintainers:
+    - open-ce/open-ce-dev-team


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Using TBB with PyTorch CPU and OpenMP with PyTorch CUDA results in different symbols being supplied with each variant of PyTorch. 
 
This PR makes torchtext cpu/cuda specific so that pytorch and torchtext are in sync. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
